### PR TITLE
Giving the request object as an additional parameter to `use` middlew…

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,18 +102,36 @@ rxws.onNotification('newPost')
   })
 ```
 
-Middleware:
+Request Middleware:
+```javascript
+// Middleware progress from one another in the order they are defined
+rxws.requestUse()
+	.subscribe(({req, send, reply, next}) => {
+		req.header.resource = 'prefix.' + req.header.resource;
+		next();
+	}, ({req, err}) => {
+		//the error function is currently never called
+	});
+```
 
+Response Middleware:
 ```javascript
 // Middleware progress from one another in the order they are defined
 rxws.use()
-	.subscribe(({res, reply, retry, next}) => {
+	.subscribe(({req, res, reply, retry, next}) => {
 		res.requestTime = Date.now();
 		next();
 	});
 
 rxws.use()
-	.subscribe(({res, reply, retry, next}) => {
+	.subscribe(({req, res, reply, retry, next}) => {
+		next();
+	}, ({req, err}) => {
+		// Do something with the error and the request.
+	});
+
+rxws.use()
+	.subscribe(({req, res, reply, retry, next}) => {
 		reply(res);
 	});
 ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A RESTful reactive JavaScript implmentation on top of web sockets",
   "main": "lib/rxws.js",
   "scripts": {
-    "test": "node node_modules/jasmine/bin/jasmine.js",
+    "test": "babel-node node_modules/jasmine/bin/jasmine.js",
     "build": "babel src --out-dir lib",
     "clean": "rm -rf lib",
     "test-watch": "node node_modules/jasmine-node/bin/jasmine-node --autoTest lib",
@@ -56,5 +56,6 @@
     "dist",
     "src",
     "lib"
-  ]
+  ],
+  "registry": "npm"
 }

--- a/src/request.spec.js
+++ b/src/request.spec.js
@@ -167,7 +167,9 @@ describe('request', () => {
 				expect('response should never come').toFail();
 				run();
 			}, (error) => {
-				expect(error).toBe('Never received server response within timeout 100');
+				expect(error.err).toBe('Never received server response within timeout 100');
+				expect(error.req).toBeTruthy();
+				expect(typeof error.req.header.correlationId).toBe('string');
 				run();
 			});
 
@@ -185,7 +187,9 @@ describe('request', () => {
 				expect('response should never come').toFail();
 				run();
 			}, (error) => {
-				expect(error).toBe('Never received server response within timeout 10000');
+				expect(error.err).toBe('Never received server response within timeout 10000');
+				expect(error.req).toBeTruthy();
+				expect(typeof error.req.header.correlationId).toBe('string');
 				run();
 			});
 
@@ -328,8 +332,10 @@ describe('request', () => {
 				resource: 'users'
 			}).subscribe((response) => {
 					expect('This should not be called').toBe('But it was');
-				}, (response) => {
-					expect(response.__header.statusCode).toBe(404);
+				}, ({req, err}) => {
+					expect(err.__header.statusCode).toBe(404);
+					expect(req).toBeTruthy();
+					expect(typeof req.header.correlationId).toBe('string');
 				});
 
 			let request = JSON.parse(backend.write.calls.argsFor(0));


### PR DESCRIPTION
…are error handlers.

This will be used for rxws-recorder to connect requests to responses, even when the response has a statusCode not 200.