### PR TITLE
Add automatic retries on connection reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf lib",
     "test-watch": "node node_modules/jasmine-node/bin/jasmine-node --autoTest lib",
     "watch": "node node_modules/babel/bin/babel.js src --out-dir lib --watch",
-    "copy": "cp -r lib ~/dev/sme-frontend/jspm_packages/npm/rxws@4.0.0/",
+    "copy": "cp -r lib ~/dev/sme-frontend/jspm_packages/npm/rxws@4.2.0/",
     "coverage": "babel-node node_modules/isparta/bin/isparta cover --report text --report html node_modules/jasmine/bin/jasmine.js"
   },
   "repository": {

--- a/src/get.spec.js
+++ b/src/get.spec.js
@@ -1,5 +1,5 @@
 import get from './get';
-import { setBackend } from './request';
+import { setBackend, reset } from './request';
 import { makeMockBackend, messagesAreEqual } from './test-utils';
 
 /* istanbul ignore next */
@@ -9,6 +9,10 @@ describe('GET', () => {
 	beforeEach(() => {
 		backend = makeMockBackend();
 		setBackend({backend: backend, url: 'someUrl'});
+	});
+
+	afterEach(() => {
+		reset();
 	});
 
 	it('should make a request', () => {

--- a/src/head.spec.js
+++ b/src/head.spec.js
@@ -1,5 +1,5 @@
 import head from './head';
-import { setBackend } from './request';
+import { setBackend, reset } from './request';
 import { makeMockBackend, messagesAreEqual } from './test-utils';
 
 /* istanbul ignore next */
@@ -9,6 +9,10 @@ describe('HEAD', () => {
 	beforeEach(() => {
 		backend = makeMockBackend();
 		setBackend({backend: backend, url: 'someUrl'});
+	});
+
+	afterEach(() => {
+		reset();
 	});
 
 	it('should make a request', () => {

--- a/src/patch.spec.js
+++ b/src/patch.spec.js
@@ -1,5 +1,5 @@
 import patch from './patch';
-import { setBackend } from './request';
+import { setBackend, reset } from './request';
 import { makeMockBackend, messagesAreEqual } from './test-utils';
 
 /* istanbul ignore next */
@@ -9,6 +9,10 @@ describe('patch', () => {
 	beforeEach(() => {
 		backend = makeMockBackend();
 		setBackend({backend: backend, url: 'someUrl'});
+	});
+
+	afterEach(() => {
+		reset();
 	});
 
 	it('should make a request', () => {

--- a/src/post.spec.js
+++ b/src/post.spec.js
@@ -1,5 +1,5 @@
 import post from './post';
-import { setBackend } from './request';
+import { setBackend, reset } from './request';
 import { makeMockBackend, messagesAreEqual } from './test-utils';
 
 /* istanbul ignore next */
@@ -9,6 +9,10 @@ describe('POST', () => {
 	beforeEach(() => {
 		backend = makeMockBackend();
 		setBackend({backend: backend, url: 'someUrl'});
+	});
+
+	afterEach(() => {
+		reset();
 	});
 
 	it('should make a request', () => {

--- a/src/put.spec.js
+++ b/src/put.spec.js
@@ -1,5 +1,5 @@
 import put from './put';
-import { setBackend } from './request';
+import { setBackend, reset } from './request';
 import { makeMockBackend, messagesAreEqual } from './test-utils';
 
 /* istanbul ignore next */
@@ -9,6 +9,10 @@ describe('put', () => {
 	beforeEach(() => {
 		backend = makeMockBackend();
 		setBackend({backend: backend, url: 'someUrl'});
+	});
+
+	afterEach(() => {
+		reset();
 	});
 
 	it('should make a request', () => {

--- a/src/remove.spec.js
+++ b/src/remove.spec.js
@@ -1,5 +1,5 @@
 import remove from './remove';
-import { setBackend } from './request';
+import { setBackend, reset } from './request';
 import { makeMockBackend, messagesAreEqual } from './test-utils';
 
 /* istanbul ignore next */
@@ -9,6 +9,10 @@ describe('remove', () => {
 	beforeEach(() => {
 		backend = makeMockBackend();
 		setBackend({backend: backend, url: 'someUrl'});
+	});
+
+	afterEach(() => {
+		reset();
 	});
 
 	it('should make a request', () => {
@@ -105,4 +109,54 @@ describe('remove', () => {
 		expect(function() { remove('users.comments').subscribe(function() {}) }).toThrow();
 		expect(function() { remove('users.comments').subscribe(function() {}) }).toThrowError('Invalid params: param is required for resource users');
 	})
+
+	it('should execute onConnectionError callback', (run) => {
+		setBackend({backend: backend, url: 'someUrl', onConnectionError: (error) => {
+			expect(error).toBe('Lost connection');
+			run();
+		}});
+
+		backend.makeConnectionError();
+	});
+
+	it('should retry outstanding requests when the connection resets', (run) => {
+		setBackend({backend: backend, url: 'someUrl', onConnectionError: (error) => {
+			expect(error).toBe('Lost connection');
+			setTimeout(() => {
+				expect(backend.write.calls.count()).toBe(2);
+				expect(messagesAreEqual(
+					backend.write.calls.argsFor(0),
+					backend.write.calls.argsFor(1),
+					true
+				)).toBeTruthy();
+				run();
+			}, 10);
+		}});
+
+		remove('wow').subscribe(() => {});
+
+		expect(backend.write.calls.count()).toBe(1);
+
+		backend.makeConnectionError();
+	});
+
+	it('should retry outstanding requests only once', (run) => {
+		let tries = 0;
+		setBackend({backend: backend, url: 'someUrl', onConnectionError: (error) => {
+			tries++;
+
+			setTimeout(() => {
+				if (tries === 1) {
+					expect(backend.write.calls.count()).toBe(2);
+					backend.makeConnectionError();
+				} else {
+					expect(backend.write.calls.count()).toBe(2);
+					run();
+				}
+			}, tries === 1 ? 10 : 2000);
+		}});
+
+		remove('wow').subscribe(() => {});
+		backend.makeConnectionError();
+	});
 });

--- a/src/request.js
+++ b/src/request.js
@@ -201,8 +201,8 @@ export function setBackend(_options = {}) {
 			}
 			return i;
 		}).flatMap(function(i) {
-			const seconds = getRetryTimer(i);
-			console.log("delay retry by " + (seconds / 1000) + " second(s)");
+			const ms = getRetryTimer(i);
+			console.log("delay retry by " + (ms / 1000) + " second(s)");
 			return Observable.timer(seconds);
 		});
 	}).subscribe((response) => {

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -4,12 +4,15 @@ import { isEqual, cloneDeep } from 'lodash';
 /* istanbul ignore next */
 export function makeMockBackend() {
 	let callback;
+	let _makeConnectionError;
 
 	let backend = {
 		connect(url) {
 			return Observable.create((observer) => {
 				observer.onNext();
-				observer.onCompleted();
+				_makeConnectionError = function() {
+					observer.onError('Lost connection');
+				}
 			})
 		},
 
@@ -32,6 +35,7 @@ export function makeMockBackend() {
 	spyOn(backend, 'write');
 	spyOn(backend, 'onMessage').and.callThrough();
 	spyOn(backend, 'close');
+	backend.makeConnectionError = () => _makeConnectionError();
 
 	return backend;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ function sanitizeParams(resource, params) {
  */
 export function getRetryTimer(i) {
 	const CAP = 15000;
-	const BASE = 400;
+	const BASE = 300;
 
 	const temp = Math.min(CAP, BASE * 2 * (i - 1));
 	return temp / 2 + (Math.random() * temp);


### PR DESCRIPTION
If the connection is reset, automatically retry
any outstanding requests. At most, retry once.