### PR TITLE
Make sure that GET and HEAD requests don't include a body.

### DIFF
--- a/src/HTTPBackend.js
+++ b/src/HTTPBackend.js
@@ -78,7 +78,7 @@ export default function(options) {
 		const query = request.header.queryParameters || {};
 
 		let list = resource.split('.');
-		const method = list.shift();
+		const method = list.shift().toUpperCase();
 		const path = list.reduce(toPath.bind(null, params), '');
 
 
@@ -91,11 +91,16 @@ export default function(options) {
 
 		const body = request.body || '';
 
-		return fetch(`${url}${path}${getQueryString(query)}`, {
-			method: method.toUpperCase(),
+		let requestOptions = {
+			method,
 			headers,
-			body: (method === 'get' || method === 'head') ? null : JSON.stringify(body)
-		})
+		};
+
+		if (method !== 'GET' && method !== 'HEAD') {
+			requestOptions.body = JSON.stringify(body);
+		}
+
+		return fetch(`${url}${path}${getQueryString(query)}`, requestOptions)
 
 		function toPath(params, path, res) {
 			if (params[res] === undefined || params[res] === null) {

--- a/src/HTTPBackend.spec.js
+++ b/src/HTTPBackend.spec.js
@@ -291,7 +291,7 @@ describe('HTTP Backend', function() {
 			const requestOptions = fetchSpy.calls.argsFor(0)[1];
 
 			expect(requestOptions.method).toBe('GET');
-			expect(requestOptions.body).toBe(null);
+			expect(requestOptions.body).toBe(undefined);
 
 			run();
 		});


### PR DESCRIPTION
`body: null` passed to the fetch api break in the new version of edge and ff
