### PR TITLE
Always reset mocked return values, even when subscribers throw error

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -300,8 +300,11 @@ export function mockReturn(key, value) {
 		else
 			replyObj.body = {[key]: value};
 
-		reply(replyObj);
-		reset();
+		try {
+			reply(replyObj);
+		} finally {
+			reset();
+		}
 	});
 }
 


### PR DESCRIPTION
calling `reply` will call all of the subscribers synchronously. If any subscribers die in their `onNext`, then the `reset` was not getting called